### PR TITLE
Remove unnecessary devDependencies

### DIFF
--- a/.remarkrc.js
+++ b/.remarkrc.js
@@ -1,15 +1,3 @@
 'use strict'
 
-exports.plugins = [
-  [
-    require('remark-retext'),
-    require('unified')().use({
-      plugins: [
-        require('retext-english'),
-        require('retext-syntax-urls'),
-        [require('./'), {dictionary: require('dictionary-en')}],
-      ],
-    }),
-  ],
-  require('remark-preset-stoicism'),
-]
+exports.plugins = [require('remark-preset-stoicism')]

--- a/license.md
+++ b/license.md
@@ -9,15 +9,15 @@ possible, while protecting contributors from liability.
 
 ## Acceptance
 
-In order to receive this license, you must agree to its rules.  The rules of
-this license are both obligations under that agreement and conditions to your
+In order to receive this license, you must agree to its rules. The rules of this
+license are both obligations under that agreement and conditions to your
 license. You must not do anything with this software that triggers a rule that
 you cannot or will not follow.
 
 ## Copyright
 
 Each contributor licenses you to do everything with this software that would
-otherwise infringe that contributor's copyright in it.
+otherwise infringe that contributor’s copyright in it.
 
 ## Notices
 
@@ -29,7 +29,7 @@ you, with or without changes, also gets the text of this license or a link to
 
 If anyone notifies you in writing that you have not complied with
 [Notices](#notices), you can keep your license by taking all practical steps to
-comply within 30 days after the notice.  If you do not do so, your license ends
+comply within 30 days after the notice. If you do not do so, your license ends
 immediately.
 
 ## Patent

--- a/package-lock.json
+++ b/package-lock.json
@@ -571,6 +571,12 @@
       "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
       "dev": true
     },
+    "emoticon": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/emoticon/-/emoticon-3.2.0.tgz",
+      "integrity": "sha512-SNujglcLTTg+lDAcApPNgEdudaqQFiAbJCqzjNxJkvN9vAwCGi0uu8IUVvx+f16h+V44KCY6Y2yboroc9pilHg==",
+      "dev": true
+    },
     "error-ex": {
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.2.tgz",
@@ -1113,6 +1119,12 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz",
       "integrity": "sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc=",
+      "dev": true
+    },
+    "gemoji": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/gemoji/-/gemoji-5.0.1.tgz",
+      "integrity": "sha512-7yV9K8JdiK+h2M4YDnf/8bunJKYvs0t0p8eKh7zexVSuXddRG9Ue18ZViKOZljISk57DE64X19gvJfHZmhggGg==",
       "dev": true
     },
     "get-caller-file": {
@@ -1700,6 +1712,12 @@
         "repeat-string": "^1.0.0"
       }
     },
+    "match-casing": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/match-casing/-/match-casing-1.0.3.tgz",
+      "integrity": "sha512-oMyC3vUVCFbGu+M2Zxl212LPJThcaw7QxB5lFuJPQCgV/dsGBP0yZeCoLmX6CiBkoBcVbAKDJZrBpJVu0XcLMw==",
+      "dev": true
+    },
     "mdast-util-compact": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/mdast-util-compact/-/mdast-util-compact-2.0.1.tgz",
@@ -1781,12 +1799,74 @@
       "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
       "dev": true
     },
+    "nlcst-affix-emoticon-modifier": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/nlcst-affix-emoticon-modifier/-/nlcst-affix-emoticon-modifier-1.1.4.tgz",
+      "integrity": "sha512-GfjDXjd3pMm1M8CxDd/8arRKKI9Vw+pRXTdmLjCupawRY6cyKs8rveUVkIsqll9XlDb1CzmRJnJeQR8nZqZjVg==",
+      "dev": true,
+      "requires": {
+        "unist-util-modify-children": "^1.0.0"
+      }
+    },
+    "nlcst-emoji-modifier": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/nlcst-emoji-modifier/-/nlcst-emoji-modifier-4.1.0.tgz",
+      "integrity": "sha512-0x+tliy8xpoJmde8R4UNNPoLk0sgYucRSBDcm8U+nngj9r5S01mQ5bdLF24OjFWnRAi6EGcGHQgFFmEOQPCfxA==",
+      "dev": true,
+      "requires": {
+        "emoji-regex": "^9.0.0",
+        "gemoji": "^5.0.0",
+        "nlcst-to-string": "^2.0.0",
+        "unist-util-generated": "^1.0.0",
+        "unist-util-position": "^3.0.0",
+        "unist-util-visit": "^2.0.0"
+      },
+      "dependencies": {
+        "emoji-regex": {
+          "version": "9.0.0",
+          "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.0.0.tgz",
+          "integrity": "sha512-6p1NII1Vm62wni/VR/cUMauVQoxmLVb9csqQlvLz+hO2gk8U2UYDfXHQSUYIBKmZwAKz867IDqG7B+u0mj+M6w==",
+          "dev": true
+        }
+      }
+    },
+    "nlcst-emoticon-modifier": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/nlcst-emoticon-modifier/-/nlcst-emoticon-modifier-1.1.4.tgz",
+      "integrity": "sha512-fk1iv3Vw3fVKWYDeFgvtK4cZKzu63/1+omPGPIIQ8McKInZsdlRY8E9DWRXperdtVRTSDD0BxVImoPjO1WNxOA==",
+      "dev": true,
+      "requires": {
+        "emoticon": "^3.0.0",
+        "nlcst-to-string": "^2.0.0",
+        "unist-util-modify-children": "^1.0.0"
+      }
+    },
     "nlcst-is-literal": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/nlcst-is-literal/-/nlcst-is-literal-1.2.1.tgz",
       "integrity": "sha512-abNv1XY7TUoyLn5kSSorMIYHfRvVfXbgftNFNvEMiQQkyKteLdjrGuDqEMMyK70sMbn7uPA6oUbRvykM6pg+pg==",
       "requires": {
         "nlcst-to-string": "^2.0.0"
+      }
+    },
+    "nlcst-normalize": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/nlcst-normalize/-/nlcst-normalize-2.1.4.tgz",
+      "integrity": "sha512-dWJ3XUoAoWoau24xOM59Y1FPozv7DyYWy+rdUaXj9Ow0hBCVuwqDQbXzTF7H+HskyTVpTkRPXYPu4YsMEScmRw==",
+      "dev": true,
+      "requires": {
+        "nlcst-to-string": "^2.0.0"
+      }
+    },
+    "nlcst-search": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/nlcst-search/-/nlcst-search-2.0.0.tgz",
+      "integrity": "sha512-+3xdctMFTcG+76vKAa0wObNg1EYq7IIQlZcL+HxSFXkHO1DgSPRjsPJrmelVIvMg7rk+wmBcdPEoScv/CTT1Zw==",
+      "dev": true,
+      "requires": {
+        "nlcst-is-literal": "^1.0.0",
+        "nlcst-normalize": "^2.0.0",
+        "unist-util-visit": "^2.0.0"
       }
     },
     "nlcst-to-string": {
@@ -1836,6 +1916,12 @@
       "requires": {
         "is-buffer": "^2.0.0"
       }
+    },
+    "number-to-words": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/number-to-words/-/number-to-words-1.2.4.tgz",
+      "integrity": "sha512-/fYevVkXRcyBiZDg6yzZbm0RuaD6i0qRfn8yr+6D0KgBMOndFPxuW10qCHpzs50nN8qKuv78k8MuotZhcVX6Pw==",
+      "dev": true
     },
     "object-inspect": {
       "version": "1.7.0",
@@ -2902,7 +2988,7 @@
       }
     },
     "remark-preset-stoicism": {
-      "version": "git+https://github.com/stoicism-compendium/remark-preset-stoicism.git#f54e986ca5b484e53cfbe0e6526127039c89b303",
+      "version": "git+https://github.com/stoicism-compendium/remark-preset-stoicism.git#94fb5173e698d1f464d5ae5d3c074344db664cf0",
       "from": "git+https://github.com/stoicism-compendium/remark-preset-stoicism.git",
       "dev": true,
       "requires": {
@@ -2958,7 +3044,10 @@
         "remark-lint-table-pipe-alignment": "^2.0.0",
         "remark-lint-table-pipes": "^2.0.0",
         "remark-lint-unordered-list-marker-style": "^2.0.0",
-        "remark-validate-links": "^10.0.0"
+        "remark-retext": "^4.0.0",
+        "remark-validate-links": "^10.0.0",
+        "retext-preset-stoicism": "git+https://github.com/stoicism-compendium/retext-preset-stoicism.git",
+        "unified": "^9.0.0"
       }
     },
     "remark-retext": {
@@ -3074,6 +3163,45 @@
         "signal-exit": "^3.0.2"
       }
     },
+    "retext-contractions": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/retext-contractions/-/retext-contractions-4.0.0.tgz",
+      "integrity": "sha512-0T+QE+mFBfYiZHqD+86yM19PjEN3w6Z2boTWpYZb4L6JyzMN4luHUzNHwaL8HtkbxHEe0j8yqLrYnTD+qoOEyw==",
+      "dev": true,
+      "requires": {
+        "nlcst-is-literal": "^1.0.0",
+        "nlcst-to-string": "^2.0.0",
+        "unist-util-visit": "^2.0.0"
+      }
+    },
+    "retext-diacritics": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/retext-diacritics/-/retext-diacritics-3.0.0.tgz",
+      "integrity": "sha512-QayeY2hpQ1UEsPlderfl6k90sA+mSxnlOMqiA3N5teDPyKo3REwkm+o/fClCxjLSm6NJgqNthOZjjSBUgQvSSw==",
+      "dev": true,
+      "requires": {
+        "match-casing": "^1.0.0",
+        "nlcst-search": "^2.0.0",
+        "nlcst-to-string": "^2.0.0",
+        "quotation": "^1.0.1",
+        "unist-util-position": "^3.0.0"
+      }
+    },
+    "retext-emoji": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/retext-emoji/-/retext-emoji-7.0.1.tgz",
+      "integrity": "sha512-oZxqCYO7ljD1CVMtX1b4Ph65VnskkR8vIPqb58Me0a6/ST5ZkiajIY7CpM1YUNlJ+KToYcZiZbMnyam0w8rGIQ==",
+      "dev": true,
+      "requires": {
+        "emoticon": "^3.1.0",
+        "gemoji": "^5.0.0",
+        "nlcst-affix-emoticon-modifier": "^1.0.0",
+        "nlcst-emoji-modifier": "^4.0.0",
+        "nlcst-emoticon-modifier": "^1.0.0",
+        "nlcst-to-string": "^2.0.0",
+        "unist-util-visit": "^2.0.0"
+      }
+    },
     "retext-english": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/retext-english/-/retext-english-3.0.4.tgz",
@@ -3082,6 +3210,86 @@
       "requires": {
         "parse-english": "^4.0.0",
         "unherit": "^1.0.4"
+      }
+    },
+    "retext-indefinite-article": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/retext-indefinite-article/-/retext-indefinite-article-2.0.1.tgz",
+      "integrity": "sha512-rOaVwz24DHR8v7/RtX8b0ZvSXjw4071YxoLrFWAk54Lx/yB5EKLxVFjQtbeE5IroX+2w+3Uizk68731ra0cNCw==",
+      "dev": true,
+      "requires": {
+        "format": "^0.2.2",
+        "nlcst-to-string": "^2.0.0",
+        "number-to-words": "^1.2.3",
+        "unist-util-is": "^4.0.0",
+        "unist-util-visit": "^2.0.0"
+      }
+    },
+    "retext-preset-stoicism": {
+      "version": "git+https://github.com/stoicism-compendium/retext-preset-stoicism.git#757a6250c4c9d6d1cee57966ee96680d659fa7b8",
+      "from": "git+https://github.com/stoicism-compendium/retext-preset-stoicism.git",
+      "dev": true,
+      "requires": {
+        "dictionary-en": "^3.0.0",
+        "retext-contractions": "^4.0.0",
+        "retext-diacritics": "^3.0.0",
+        "retext-emoji": "^7.0.1",
+        "retext-english": "^3.0.4",
+        "retext-indefinite-article": "^2.0.1",
+        "retext-quotes": "^4.0.0",
+        "retext-redundant-acronyms": "^3.0.0",
+        "retext-repeated-words": "^3.0.0",
+        "retext-sentence-spacing": "^4.0.0",
+        "retext-spell-file": "git+https://github.com/stoicism-compendium/retext-spell-file.git",
+        "retext-syntax-urls": "^2.0.0"
+      }
+    },
+    "retext-quotes": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/retext-quotes/-/retext-quotes-4.0.0.tgz",
+      "integrity": "sha512-YtHJ3Yw0yk8sGp0FMAVWe2a/q0DaHjSKfrAYkO5rZXLofGYYG+LCoqzqlX0tbfae1ImlsqhsLVCuZ0fkUO087g==",
+      "dev": true,
+      "requires": {
+        "nlcst-to-string": "^2.0.0",
+        "unist-util-is": "^4.0.0",
+        "unist-util-visit": "^2.0.0"
+      }
+    },
+    "retext-redundant-acronyms": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/retext-redundant-acronyms/-/retext-redundant-acronyms-3.0.0.tgz",
+      "integrity": "sha512-pu5um9ObH+j/AguHPVm+u23DK43zey2Jim0dmzccczvilbIRiYh7ZQMSOIuLNpE+7jNP0quX3oe/ommrLlwECQ==",
+      "dev": true,
+      "requires": {
+        "nlcst-normalize": "^2.0.0",
+        "nlcst-search": "^2.0.0",
+        "nlcst-to-string": "^2.0.0",
+        "pluralize": "^8.0.0",
+        "quotation": "^1.0.0",
+        "unist-util-find-after": "^3.0.0",
+        "unist-util-position": "^3.0.0"
+      }
+    },
+    "retext-repeated-words": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/retext-repeated-words/-/retext-repeated-words-3.0.0.tgz",
+      "integrity": "sha512-c9awbCxn3h+SVVYwEeJA+rcWWFiOvxrcD8MVFpyVpWu0q1cXG7NIyWclEzXDV12SkqKgR/vmBJh3tIJCfxmDAA==",
+      "dev": true,
+      "requires": {
+        "nlcst-to-string": "^2.0.0",
+        "unist-util-is": "^4.0.0",
+        "unist-util-visit": "^2.0.0"
+      }
+    },
+    "retext-sentence-spacing": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/retext-sentence-spacing/-/retext-sentence-spacing-4.0.0.tgz",
+      "integrity": "sha512-CKdHlVBbZDkdjxZ1IctBQ1u4/sHQraGoTuI8qvB2C4jSaM0MEY0hxpMdVjnznWAWm4VOqwSXZDkR71Pv6Yw0TA==",
+      "dev": true,
+      "requires": {
+        "nlcst-to-string": "^2.0.0",
+        "unist-util-is": "^4.0.0",
+        "unist-util-visit": "^2.0.0"
       }
     },
     "retext-spell": {
@@ -3094,6 +3302,15 @@
         "nspell": "^2.0.0",
         "quotation": "^1.1.0",
         "unist-util-visit": "^2.0.0"
+      }
+    },
+    "retext-spell-file": {
+      "version": "git+https://github.com/stoicism-compendium/retext-spell-file.git#3e36f4f49a086180ab48fef367ca4ea5bb1ae382",
+      "from": "git+https://github.com/stoicism-compendium/retext-spell-file.git",
+      "dev": true,
+      "requires": {
+        "find-up": "^4.1.0",
+        "retext-spell": "^4.0.0"
       }
     },
     "retext-syntax-urls": {
@@ -3649,6 +3866,15 @@
       "dev": true,
       "requires": {
         "wrapped": "^1.0.1"
+      }
+    },
+    "unist-util-find-after": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/unist-util-find-after/-/unist-util-find-after-3.0.0.tgz",
+      "integrity": "sha512-ojlBqfsBftYXExNu3+hHLfJQ/X1jYY/9vdm4yZWjIbf0VuWF6CRufci1ZyoD/wV2TYMKxXUoNuoqwy+CkgzAiQ==",
+      "dev": true,
+      "requires": {
+        "unist-util-is": "^4.0.0"
       }
     },
     "unist-util-generated": {

--- a/package.json
+++ b/package.json
@@ -27,7 +27,6 @@
   },
   "devDependencies": {
     "depcheck": "^0.9.2",
-    "dictionary-en": "^3.0.0",
     "eslint": "^7.2.0",
     "eslint-config-standard": "^14.1.1",
     "eslint-plugin-import": "^2.21.2",
@@ -35,11 +34,7 @@
     "eslint-plugin-promise": "^4.2.1",
     "eslint-plugin-standard": "^4.0.1",
     "remark-cli": "^8.0.0",
-    "remark-preset-stoicism": "git+https://github.com/stoicism-compendium/remark-preset-stoicism.git",
-    "remark-retext": "^4.0.0",
-    "retext-english": "^3.0.4",
-    "retext-syntax-urls": "^2.0.0",
-    "unified": "^9.0.0"
+    "remark-preset-stoicism": "git+https://github.com/stoicism-compendium/remark-preset-stoicism.git"
   },
   "scripts": {
     "depcheck": "depcheck",


### PR DESCRIPTION
`remark-preset-stoicism` now includes `retext-preset-stoicism`, which itself includes `retext-spell-file`. So, we just need `remark-preset-stoicism` as the sole plugin.