### PR TITLE
Run require-self as prepare script

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "format": "npm run format-md && npm run format-js",
     "format-js": "prettier --write '**/*.js' && eslint --fix .",
     "format-md": "remark --output --quiet --frail .",
-    "postinstall": "require-self",
+    "prepare": "require-self",
     "test": "npm run check-md && npm run check-js && npm run depcheck"
   },
   "eslintIgnore": [


### PR DESCRIPTION
Use `prepare` instead of `postinstall` because the latter is run during
`npm install retext-spell-file` while the former is not.

See https://docs.npmjs.com/using-npm/scripts#life-cycle-scripts