### PR TITLE
Remove require-self from prepare script

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -28,4 +28,6 @@ jobs:
       with:
         node-version: ${{ matrix.node-version }}
     - run: npm install
+    # This uses the cyclical dependency to self-test.
+    - run: npx require-self
     - run: npm test

--- a/package.json
+++ b/package.json
@@ -35,7 +35,6 @@
     "prettier": "*",
     "remark-cli": "^8.0.0",
     "remark-preset-stoicism": "git+https://github.com/stoicism-compendium/remark-preset-stoicism.git",
-    "require-self": "^0.2.3",
     "stoicism-js-style": "git+https://github.com/stoicism-compendium/stoicism-js-style.git"
   },
   "scripts": {
@@ -45,7 +44,6 @@
     "format": "npm run format-md && npm run format-js",
     "format-js": "prettier --write '**/*.js' && eslint --fix .",
     "format-md": "remark --output --quiet --frail .",
-    "prepare": "require-self",
     "test": "npm run check-md && npm run check-js && npm run depcheck"
   },
   "eslintIgnore": [


### PR DESCRIPTION
Use `require-self` in the CI test instead. It seems to be causing a self-referential nightmare with my other packages.