### PR TITLE
Remove prepare script, use require-self in pretest

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,5 +28,5 @@ jobs:
       with:
         node-version: ${{ matrix.node-version }}
     - run: npm install
-    - run: npm pretest # Set up the self-dependency for testing.
+    - run: npm run pretest # Set up the self-dependency for testing.
     - run: npm test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,4 +28,5 @@ jobs:
       with:
         node-version: ${{ matrix.node-version }}
     - run: npm install
+    - run: npm pretest # Set up the self-dependency for testing.
     - run: npm test

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "format": "npm run format-md && npm run format-js",
     "format-js": "prettier --write '**/*.js' && eslint --fix .",
     "format-md": "remark --output --quiet --frail .",
-    "prepare": "require-self",
+    "pretest": "require-self",
     "test": "npm run check-md && npm run check-js && npm run depcheck"
   },
   "eslintIgnore": [


### PR DESCRIPTION
It doesn't work to have `require-self` in the `prepare` script because `npm publish` runs `prepare` and doesn't find `require-self`. I suppose we could instead run `npm install` before `npm publish`, but I don't think that should be required.

Instead, we created a `pretest` script to run `require-self`. We run that in CI after `npm install` and before `npm test`.